### PR TITLE
Try to save state, but be OK if we can't.

### DIFF
--- a/client/scripts/main.js
+++ b/client/scripts/main.js
@@ -11,7 +11,11 @@ var __listen_to_the_ft = (function(){
 		var stored = localStorage.getItem(storageKey);
 		
 		function save(){
-			localStorage.setItem(storageKey, JSON.stringify( stored ) );
+			try{
+				localStorage.setItem(storageKey, JSON.stringify( stored ) );
+			} catch(err){
+				console.log('Error trying to save state', err);
+			}
 		}
 
 		function addItemForStorage(key, value){


### PR DESCRIPTION
We like to try and remember what a user has played on their device. If someone is using the app in the iOS 'private browser', no memory quota is assigned to the app, and so the storage fails. We get [this message](http://stackoverflow.com/questions/14555347/html5-localstorage-error-with-safari-quota-exceeded-err-dom-exception-22-an). 

This PR handles the issue on iOS devices.